### PR TITLE
Restore option to mute sound in settings.js

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -569,6 +569,7 @@ var actionList = [
         [null, 'sound-submenu'         ,   _('Media'),                                    true,  'audio-volume-medium-symbolic'],
         [   1, 'volume-up'             ,   _('Volume Up'),                                true,  'audio-volume-high-symbolic'],
         [   1, 'volume-down'           ,   _('Volume Down'),                              true,  'audio-volume-low-symbolic'],
+        [   1, 'mute-sound'            ,   _('Volume Mute toggle'),                       true,  'audio-volume-muted-symbolic'],
         [   1, 'mpris-play-pause'      ,   _('Media key - Play/Pause'),                  false,  'media-playback-start-symbolic'],
         [   1, 'mpris-next'            ,   _('Media key - Next Track'),                  false,  'media-skip-forward-symbolic'],
         [   1, 'mpris-prev'            ,   _('Media key - Previous Track'),              false,  'media-skip-backward-symbolic'],


### PR DESCRIPTION
Since other files still contain the mute sound code I'm assuming that the re-categorization of "Sound" to "Media" inadvertently caused the loss of the mute sound option. This fixes that problem.