### PR TITLE
Update custom-hot-corners-extended.pot

### DIFF
--- a/po/custom-hot-corners-extended.pot
+++ b/po/custom-hot-corners-extended.pot
@@ -328,7 +328,7 @@ msgid "Collapse all"
 msgstr ""
 
 #: prefs.js:1167
-msgid "Show acive items only"
+msgid "Show active items only"
 msgstr ""
 
 #: prefs.js:1200


### PR DESCRIPTION
fix(ui): Typo in "Show **active** items only" button.

before: Show **acive** items only
