### PR TITLE
Show all windows for a single app

### DIFF
--- a/src/extension/actionTrigger.js
+++ b/src/extension/actionTrigger.js
@@ -127,6 +127,10 @@ var ActionTrigger = class ActionTrigger {
         });
     }
 
+    _toggleOverviewWin () {
+        this.actions.toggleOverviewAppWindows()
+    }
+
     _toggleOverview() {
         this.actions.toggleOverview(true);
     }

--- a/src/extension/actions.js
+++ b/src/extension/actions.js
@@ -770,6 +770,18 @@ var Actions = class {
         // global.display.get_tab_list(0, null)[1].activate(global.get_current_time());
     }
 
+    toggleOverviewAppWindows() {
+        const isOverviewWindow = Workspace.prototype._isOverviewWindow
+        Workspace.prototype._isOverviewWindow = (win) => {
+			const activeWindow = global.display.focus_window;
+			return (!activeWindow)
+				? isOverviewWindow(win)
+				: (activeWindow.wm_class == win.wm_class);
+		};
+		Main.overview.toggle();
+        Workspace.prototype._isOverviewWindow = isOverviewWindow;
+    }
+
     closeWindow() {
         let win = this._getFocusedWindow(true);
         if (!win)

--- a/src/prefs/actionList.js
+++ b/src/prefs/actionList.js
@@ -113,6 +113,7 @@ var actionList = [
     [1,    'app-switcher-popup-mon',      _('App Switcher Popup (current monitor)'),     true,  'focus-windows-symbolic',                     false],
 
     [null, 'win-control-submenu',         _('Windows - Control'),                        true,  'focus-windows-symbolic',                     false],
+    [1,    'toggle-overview-win',         _('App Windows Overiew'),                     false, 'focus-windows-symbolic',                    true],
     [1,    'minimize-win',                _('Minimize Window'),                         false,  'window-minimize-symbolic',                    true],
     [1,    'maximize-win',                _('Maximize Window (toggle)'),                false,  'window-maximize-symbolic',                    true],
     [1,    'close-win',                   _('Close Window'),                            false,  'window-close-symbolic',                       true],


### PR DESCRIPTION
add a new action in window control sub menu which will show all windows of the current focused app, like the one in macos